### PR TITLE
Increase test coverage for unit tests

### DIFF
--- a/spec/unit/apply_prompt_spec.rb
+++ b/spec/unit/apply_prompt_spec.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
+require 'tty/prompt'
+
 RSpec.describe RubyEdit::ApplyPrompt do
   let(:prompt) { RubyEdit::ApplyPrompt.new }
 
   it 'should respond to #continue?' do
-    expect(prompt).to respond_to :continue?
-    expect(prompt).to receive(:continue?)
-    prompt.continue?
+    expect_any_instance_of(TTY::Prompt).to receive(:yes?).and_return(true)
+    expect(prompt.continue?).to be_truthy
   end
 end
 

--- a/spec/unit/editor_spec.rb
+++ b/spec/unit/editor_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'tty/editor'
+
 RSpec.describe RubyEdit::Editor do
   let(:editor) { RubyEdit::Editor.new }
 
@@ -9,9 +11,8 @@ RSpec.describe RubyEdit::Editor do
 
   describe '#edit_sourcefile' do
     it 'should open the sourcefile in an editor' do
-      expect(editor).to receive(:edit_sourcefile)
-      editor.edit_sourcefile
-      expect(editor).to respond_to :edit_sourcefile
+      expect(TTY::Editor).to receive(:open).and_return(true)
+      expect(editor.edit_sourcefile).to be_truthy
     end
   end
 end


### PR DESCRIPTION
How?
- Stubbed out tty prompt and editor to allow certain methods to be called without stalling the specs.