### PR TITLE
Changed the default path from '.' to '*'

### DIFF
--- a/lib/ruby_edit/grep.rb
+++ b/lib/ruby_edit/grep.rb
@@ -7,7 +7,7 @@ module RubyEdit
     attr_reader :result
 
     def initialize(options)
-      @path       = options[:path] || '.'
+      @path       = options[:path] || '*'
       @expression = options[:expression]
     end
 


### PR DESCRIPTION
Why?
- Allows for more accurrate recursive searching.