### PR TITLE
Fixed broken regex for detecting the line in files.

### DIFF
--- a/lib/ruby_edit/writer.rb
+++ b/lib/ruby_edit/writer.rb
@@ -6,7 +6,7 @@ require 'ruby_edit/command'
 
 module RubyEdit
   class Writer < RubyEdit::Command
-    LINE_REGEX = /^.*:\d:+/
+    LINE_REGEX = /^.*:\d+:/
 
     def write
       File.open(RubyEdit::SOURCE_FILE_LOCATION, 'rb') do |file|


### PR DESCRIPTION
Why?
- The + should have been after \d, but instead it was after the colon.