### PR TITLE
Changed Commands::Edit to Commands::Text

### DIFF
--- a/lib/ruby_edit/cli.rb
+++ b/lib/ruby_edit/cli.rb
@@ -45,8 +45,8 @@ module RubyEdit
       elsif options.empty?
         invoke :help
       else
-        require_relative 'commands/edit'
-        RubyEdit::Commands::Edit.new(options).execute
+        require_relative 'commands/text'
+        RubyEdit::Commands::Text.new(options).execute
       end
     end
 

--- a/lib/ruby_edit/commands/text.rb
+++ b/lib/ruby_edit/commands/text.rb
@@ -9,7 +9,7 @@ require 'ruby_edit/text/writer'
 
 module RubyEdit
   module Commands
-    class Edit
+    class Text
       def initialize(options)
         @grep       = RubyEdit::Text::Grep.new(options)
         @sourcefile = RubyEdit::SourceFile.new

--- a/spec/unit/commands/text_spec.rb
+++ b/spec/unit/commands/text_spec.rb
@@ -3,12 +3,12 @@
 require 'tty/editor'
 require 'tty/command'
 
-RSpec.describe RubyEdit::Commands::Edit do
+RSpec.describe RubyEdit::Commands::Text do
   # TODO: This needs cleaning up!
   let(:output) { StringIO.new }
   let(:options) { { path: '.', expression: 'TEXT_TO_CHANGE' } }
   let(:command) do
-    RubyEdit::Commands::Edit.new(options).tap do |edit|
+    RubyEdit::Commands::Text.new(options).tap do |edit|
       edit.instance_variable_set('@output', output)
     end
   end
@@ -31,7 +31,7 @@ RSpec.describe RubyEdit::Commands::Edit do
     expect_any_instance_of(RubyEdit::SourceFile).to receive(:delete).and_return(true)
     expect_any_instance_of(TTY::Prompt).to receive(:yes?).and_return(true)
     expect_any_instance_of(RubyEdit::Text::Writer).to receive(:write).and_return(true)
-    # expect_any_instance_of(RubyEdit::Commands::Edit).to receive(:apply_changes).and_return(true)
+    # expect_any_instance_of(RubyEdit::Commands::Text).to receive(:apply_changes).and_return(true)
     expect(command.execute).to be_truthy
   end
 end


### PR DESCRIPTION
Why?
- Once the functionality for editing files and directories is added this will make more sense